### PR TITLE
Add missing libraries to linker flags

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@
 
 module(
     name = "score_toolchains_gcc",
-    version = "0.2",
+    version = "0.3",
     compatibility_level = 0,
 )
 

--- a/toolchain/internal/cc_toolchain_config.bzl
+++ b/toolchain/internal/cc_toolchain_config.bzl
@@ -211,6 +211,9 @@ def _impl(ctx):
     )
 
     linker_flags = [
+        "-lm",
+        "-ldl",
+        "-lrt",
         "-static-libstdc++",
         "-static-libgcc",
     ]


### PR DESCRIPTION
To compile the communication module, additional libraries must be linked.

Related to https://github.com/eclipse-score/communication/issues/3