### PR TITLE
Fixes  #13,Support the linkage of the C++ standard library with Rust …

### DIFF
--- a/toolchain/internal/cc_toolchain_config.bzl
+++ b/toolchain/internal/cc_toolchain_config.bzl
@@ -344,6 +344,26 @@ def _impl(ctx):
         ],
     )
 
+    link_std_cpp_lib_feature = feature(
+        name = "link_std_cpp_lib",
+        enabled = True,  # always enabled for now
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            # GCC toolchains
+                            "-lstdc++"
+                            # If you use clang toolchains, you might need:
+                            
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
     # The order of the features is relevant, they are applied in this specific order.
     # A command line parameter from a feature at the end of the list will appear
     # after a command line parameter from a feature at the beginning of the list.
@@ -355,6 +375,7 @@ def _impl(ctx):
         cxx20_feature,
         default_link_flags_feature,
         pthread_feature,
+        link_std_cpp_lib_feature,
         minimal_warnings_feature,
         opt_feature,
         strict_warnings_feature,


### PR DESCRIPTION
commit id : https://github.com/eclipse-score/toolchains_gcc/commit/52121f846a9cd2fe20eda3f6873c706ecef1670a

Environment tested: Ubuntu 22.04.5 LTS
I have cloned the repo and made changes and tested against https://github.com/eclipse-score/communication/blob/770fe88d37f7720fccee24d49f45e6bce12e5368/score/mw/com/example/ipc_bridge/BUILD#L83.

Problem Statement
When linking Rust binaries that depend on C++ libraries, the build currently fails with missing symbols from the C++ standard library when rustc_flags = ["-Clink-arg=-lstdc++"] is missing in the build

Current Workaround
manually adding the flags and feature link_std_cpp_lib is missing
rust_binary(
name = "ipc_bridge_rs",
srcs = ["ipc_bridge.rs"],
data = ["etc/mw_com_config.json"],
features = ["link_std_cpp_lib"],
rustc_flags = ["-Clink-arg=-lstdc++"],
deps = [
":lib_gen_rs",
"//score/mw/com/impl/rust:proxy_bridge_rs",
"@crate_index//:futures",
],
)

Proposed Solution
Introduce a centralized toolchain feature in
toolchain/internal/cc_toolchain_config.bzl:

def _link_std_cpp_lib_feature():
"""Ensures that libstdc++ is linked when C++ is used."""
return feature(
name = "link_std_cpp_lib",
enabled = True,
flag_sets = [
flag_set(
actions = all_link_actions,
flag_groups = [
flag_group(flags = ["-lstdc++"]),
],
),
],
)

And register it in the toolchain config, alongside existing features.

How it works:

If a rust_binary or rust_library depends on a cc_library, Bazel automatically adds C++ link actions.
The toolchain ensures -lstdc++ is applied automatically.
Pure Rust or pure C++ builds are unaffected.
Migration

Projects can safely remove the following from their rust_binary / rust_library rules:
features = ["link_std_cpp_lib"]
rustc_flags = ["-Clink-arg=-lstdc++"]

Before:
rust_binary(
name = "ipc_bridge_rs",
srcs = ["ipc_bridge.rs"],
features = ["link_std_cpp_lib"],
rustc_flags = ["-Clink-arg=-lstdc++"],
deps = [":lib_gen_rs", ...],
)

After (clean):
rust_binary(
name = "ipc_bridge_rs",
srcs = ["ipc_bridge.rs"],
deps = [":lib_gen_rs", ...],
)

